### PR TITLE
(#6) Bump Cake.Core to 2.0.0

### DIFF
--- a/src/Cake.Pnpm.Tests/Cake.Pnpm.Tests.csproj
+++ b/src/Cake.Pnpm.Tests/Cake.Pnpm.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Testing" Version="1.1.0" />
+        <PackageReference Include="Cake.Testing" Version="2.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
         <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="nunit" Version="3.12.0" />

--- a/src/Cake.Pnpm/Cake.Pnpm.csproj
+++ b/src/Cake.Pnpm/Cake.Pnpm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -20,12 +20,20 @@
         <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/cake-contrib/Cake.Pnpm</PackageProjectUrl>
-        <PackageTags>cake;addin;pnpm</PackageTags>
+        <PackageTags>cake;addin;pnpm;build;cake-build;script;cake-addin</PackageTags>
         <RepositoryUrl>https://github.com/cake-contrib/Cake.Pnpm.git</RepositoryUrl>
         <PackageReleaseNotes>https://github.com/cake-contrib/Cake.Pnpm/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="1.1.0" PrivateAssets="all" />
+        <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="all" />
+        <PackageReference Include="CakeContrib.Guidelines" Version="1.4.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I have also added references to CakeContrib.Guidelines and Cake.Addin.Analyzer, to get warnings about common mistakes and best practices for addins.

fixes #6 